### PR TITLE
Ali Alekperov, M3237

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(find)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(find os_finder.h os_finder.cpp main.cpp)
+
+target_link_libraries(find stdc++fs)
+
+find_package(Boost REQUIRED COMPONENTS program_options)
+
+include_directories(${Boost_INCLUDE_DIR})
+
+target_link_libraries(find ${Boost_LIBRARIES})

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,146 @@
+#include <cstdio>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <cstring>
+#include <cerrno>
+#include <charconv>
+#include <filesystem>
+
+#include <boost/program_options.hpp>
+
+#include <unistd.h>
+
+#include "os_finder.h"
+
+void validate(boost::any& v, const std::vector<std::string>& values, os_finder::size_filter* target_type, int)
+{
+	static std::regex r("[-+=]\\d+");
+
+	using namespace boost::program_options;
+
+	validators::check_first_occurrence(v);
+	const std::string& s = validators::get_single_string(values);
+
+	std::smatch match;
+	if (std::regex_match(s, match, r)) {
+		std::string arg = match[0];
+		os_finder::size_filter::cmp cmp_mode;
+		switch (arg[0])
+		{
+		case '-':
+			cmp_mode = os_finder::size_filter::cmp::less;
+			break;
+		case '+':
+			cmp_mode = os_finder::size_filter::cmp::greater;
+			break;
+		case '=':
+			cmp_mode = os_finder::size_filter::cmp::eq;
+			break;
+		}
+		size_t val;
+		std::from_chars(arg.data() + 1, arg.data() + arg.size(), val);
+		v = boost::any(os_finder::size_filter(val, cmp_mode));
+	}
+	else {
+		throw validation_error(validation_error::invalid_option_value);
+	}
+}
+
+int main(int argc, char* argv[])
+{
+	namespace po = boost::program_options;
+	auto desc = po::options_description("Allowed options");
+	desc.add_options()
+		("help", "help message")
+		("path", po::value<std::filesystem::path>(), "path")
+		("inum", po::value<std::vector<ino64_t>>(), "inode number")
+		("name", po::value<std::vector<std::string>>(), "file name")
+		("size", po::value<std::vector<os_finder::size_filter>>(), "size filter")
+		("nlinks", po::value<std::vector<nlink_t>>(), "file hard links count")
+		("exec", po::value<std::vector<std::filesystem::path>>(), "file to execute")
+	;
+	po::positional_options_description p;
+	p.add("path", -1);
+	po::variables_map vm;
+	try {
+		po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
+	} catch (const po::error& ex)
+	{
+		std::cout << ex.what() << std::endl;
+		return EXIT_FAILURE;
+	}
+	po::notify(vm);
+
+	if (vm.count("help") || !vm.count("path")) {
+		std::cout << desc << std::endl;
+		return EXIT_SUCCESS;
+	}
+
+	auto finder = os_finder();
+	if (vm.count("inum"))
+	{
+		for (const auto& inum : vm["inum"].as<std::vector<ino64_t>>())
+		{
+			finder.filter_inum(inum);
+		}
+	}
+	if (vm.count("name"))
+	{
+		for (const auto& name : vm["name"].as<std::vector<std::string>>())
+		{
+			finder.filter_name(name);
+		}
+	}
+	if (vm.count("size"))
+	{
+		for (const auto& size_filter : vm["size"].as<std::vector<os_finder::size_filter>>())
+		{
+			finder.filter_size(size_filter);
+		}
+	}
+	if (vm.count("nlinks"))
+	{
+		for (const auto& nlinks : vm["nlinks"].as<std::vector<nlink_t>>())
+		{
+			finder.filter_nlinks(nlinks);
+		}
+	}
+
+	std::vector<std::filesystem::path> found;
+	try
+	{
+		found = finder.visit(vm["path"].as<std::filesystem::path>());
+	} catch (const os_finder::finder_exception& ex)
+	{
+		std::cout << ex.what() << std::endl;
+		return EXIT_FAILURE;
+	}
+
+	if (vm.count("exec"))
+	{
+		for (const auto& exec : vm["exec"].as<std::vector<std::filesystem::path>>())
+		{
+			std::vector<char*> found_c_strs;
+			found_c_strs.reserve(found.size() + 2);
+			found_c_strs.push_back(const_cast<char*>(exec.c_str()));
+			for (auto const& path : found) {
+				found_c_strs.push_back(const_cast<char*>(path.c_str()));
+			}
+			found_c_strs.push_back(nullptr);
+
+			if (execv(found_c_strs[0], found_c_strs.data()) == -1) {
+				std::cout << "could not execute " << exec << ": " << std::strerror(errno) << std::endl;
+				return EXIT_FAILURE;
+			}
+		}
+	} else
+	{
+		for (const auto& path : found)
+		{
+			std::cout << path << std::endl;
+		}
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/os_finder.cpp
+++ b/os_finder.cpp
@@ -1,15 +1,10 @@
 #include "os_finder.h"
 
-#include <array>
-#include <algorithm>
-
 #include <sys/syscall.h>
 #include <sys/stat.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
-
-#include <iostream>
 
 namespace
 {
@@ -120,8 +115,8 @@ bool os_finder::visit_rec(std::vector<fs::path>& found, const fs::path& path, co
 						continue;
 					}
 					if (!sizes_.empty() || !nlinks_.empty()) {
-						struct stat stats {};
-						if (fstat(fd.get_fd(), &stats) == -1) {
+						struct stat stats{};
+						if (fstatat(fd.get_fd(), name.c_str(), &stats, 0) == -1) {
 							throw finder_exception(std::string("Could not stat file: ") + std::strerror(errno));
 						}
 						if (!std::all_of(sizes_.begin(), sizes_.end(), [sz = stats.st_size](const auto& filter)
@@ -130,7 +125,7 @@ bool os_finder::visit_rec(std::vector<fs::path>& found, const fs::path& path, co
 						}))
 						{
 							continue;
-						};
+						}
 						if (!nlinks_.empty() && nlinks_.find(stats.st_nlink) == nlinks_.end())
 						{
 							continue;

--- a/os_finder.cpp
+++ b/os_finder.cpp
@@ -1,0 +1,123 @@
+#include "os_finder.h"
+
+#include <array>
+#include <algorithm>
+
+#include <sys/syscall.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <iostream>
+
+namespace
+{
+	struct linux_dirent64 {
+		ino64_t d_ino;
+		off64_t d_off;
+		unsigned short d_reclen;
+		unsigned char d_type;
+		char d_name[];
+	};
+}
+
+os_finder::size_filter::size_filter(size_t val, cmp cmp_mode) : val_(val), cmp_mode_(cmp_mode) { }
+
+bool os_finder::size_filter::check(size_t sz) const noexcept
+{
+	switch (cmp_mode_)
+	{
+	case cmp::less:
+		return sz < val_;
+	case cmp::greater:
+		return sz > val_;
+	case cmp::eq:
+		return sz == val_;
+	}
+	return false;
+}
+
+void os_finder::filter_inum(ino64_t inum)
+{
+	inums_.insert(inum);
+}
+
+void os_finder::filter_name(std::string name)
+{
+	names_.insert(std::move(name));
+}
+
+void os_finder::filter_size(size_filter size)
+{
+	sizes_.push_back(std::move(size));
+}
+
+void os_finder::filter_nlinks(nlink_t nlinks)
+{
+	nlinks_.insert(nlinks);
+}
+
+namespace fs = std::filesystem;
+
+void os_finder::visit_rec(std::vector<fs::path>& found, const fs::path& path)
+{
+	int fd = open(path.c_str(), O_RDONLY | O_DIRECTORY);
+	std::array<char, 4096> buf;
+	for (auto nread = syscall(SYS_getdents64, fd, buf.data(), buf.size()); nread != 0; nread = syscall(SYS_getdents64, fd, buf.data(), buf.size())) {
+		if (nread == -1)
+		{
+			throw finder_exception(std::string("could not read dir: ") + std::strerror(errno));
+		}
+
+		for (auto ptr = buf.data(); ptr < buf.data() + nread; ptr += reinterpret_cast<linux_dirent64*>(ptr)->d_reclen) {
+			const auto entry = reinterpret_cast<linux_dirent64*>(ptr);
+			const auto name = std::string(entry->d_name);
+			if (name == "." || name == "..") {
+				continue;
+			}
+			auto cur = path / name;
+
+			if (entry->d_type == DT_REG) {
+
+				if (!inums_.empty() && inums_.find(entry->d_ino) == inums_.end())
+				{
+					continue;
+				}
+				if (!names_.empty() && names_.find(name) == names_.end())
+				{
+					continue;
+				}
+				if (!sizes_.empty() || !nlinks_.empty()) {
+					struct stat stats{};
+					if (fstat(fd, &stats) == -1) {
+						throw finder_exception(std::string("could not stat file: ") + std::strerror(errno));
+					}
+					if (!std::all_of(sizes_.begin(), sizes_.end(), [sz = stats.st_size](const auto& filter)
+					{
+						return filter.check(sz);
+					}))
+					{
+						continue;
+					};
+					if (!nlinks_.empty() && nlinks_.find(stats.st_nlink) == nlinks_.end())
+					{
+						continue;
+					}
+				}
+
+				found.push_back(std::move(cur));
+			}
+			else if (entry->d_type == DT_DIR) {
+				visit_rec(results, cur);
+			}
+		}
+	}
+}
+
+std::vector<fs::path> os_finder::visit(const fs::path& path)
+{
+	std::vector<fs::path> found;
+	visit_rec(found, path);
+	return found;
+}

--- a/os_finder.cpp
+++ b/os_finder.cpp
@@ -90,6 +90,10 @@ namespace fs = std::filesystem;
 void os_finder::visit_rec(std::vector<fs::path>& found, const fs::path& path)
 {
 	const auto fd = fd_guard(path.c_str(), O_RDONLY | O_DIRECTORY);
+	if (fd.get_fd() == -1)
+	{
+		throw finder_exception(std::string("could not open dir: ") + std::strerror(errno));
+	}
 	std::array<char, 4096> buf;
 	for (auto nread = syscall(SYS_getdents64, fd.get_fd(), buf.data(), buf.size()); nread != 0; nread = syscall(SYS_getdents64, fd.get_fd(), buf.data(), buf.size())) {
 		if (nread == -1)

--- a/os_finder.h
+++ b/os_finder.h
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstring>
 #include <filesystem>
+#include <functional>
 
 #include <sys/types.h>
 
@@ -36,14 +37,16 @@ struct os_finder
 		cmp cmp_mode_;
 	};
 
-	std::vector<std::filesystem::path> visit(const std::filesystem::path& path);
+	using callback_t = std::function<bool(const std::filesystem::path&, const std::exception&)>;
+
+	std::vector<std::filesystem::path> visit(const std::filesystem::path& path, const callback_t& on_visit_file_failed);
 	void filter_inum(ino64_t inum);
 	void filter_name(std::string name);
 	void filter_size(size_filter size);
 	void filter_nlinks(nlink_t nlinks);
 
 private:
-	void visit_rec(std::vector<std::filesystem::path>& found, const std::filesystem::path& path);
+	bool visit_rec(std::vector<std::filesystem::path>& found, const std::filesystem::path& path, const callback_t& on_visit_file_failed);
 
 	std::set<ino64_t> inums_{};
 	std::set<std::string> names_{};

--- a/os_finder.h
+++ b/os_finder.h
@@ -1,0 +1,54 @@
+#ifndef OS_FINDER_H
+#define OS_FINDER_H
+
+#include <set>
+#include <vector>
+#include <string>
+#include <stdexcept>
+#include <cerrno>
+#include <cstring>
+#include <filesystem>
+
+#include <sys/types.h>
+
+struct os_finder
+{
+	struct finder_exception : std::runtime_error
+	{
+		using std::runtime_error::runtime_error;
+	};
+
+	struct size_filter
+	{
+		enum class cmp
+		{
+			less,
+			greater,
+			eq
+		};
+
+		size_filter(size_t val, cmp cmp_mode);
+
+		bool check(size_t sz) const noexcept;
+
+	private:
+		size_t val_;
+		cmp cmp_mode_;
+	};
+
+	std::vector<std::filesystem::path> visit(const std::filesystem::path& path);
+	void filter_inum(ino64_t inum);
+	void filter_name(std::string name);
+	void filter_size(size_filter size);
+	void filter_nlinks(nlink_t nlinks);
+
+private:
+	void visit_rec(std::vector<std::filesystem::path>& found, const std::filesystem::path& path);
+
+	std::set<ino64_t> inums_{};
+	std::set<std::string> names_{};
+	std::vector<size_filter> sizes_{};
+	std::set<nlink_t> nlinks_{};
+};
+
+#endif // OS_FINDER_H


### PR DESCRIPTION
Uses -- for options instead of -.
Allows combinations of options.
Able to look for multiple inums, names, nlinks and execute multiple targets.
Each file is checked to satisfy all of the provided size filters criterias.
Uses getdents syscall.